### PR TITLE
Add GitHub Actions to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
       interval: "daily"
     reviewers:
       - "Doug-Murphy"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
* Hopefully this forces an update and it now picks up the tests project too.